### PR TITLE
fix(nasdaq): fetch index only based on weekdays (#22)

### DIFF
--- a/finq/datasets/custom.py
+++ b/finq/datasets/custom.py
@@ -22,9 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-11
-Last updated: 2023-10-13
+Last updated: 2023-10-14
 """
 
+import logging
 from finq.datasets.dataset import Dataset
 from finq.datautil import _fetch_names_and_symbols
 
@@ -35,6 +36,8 @@ from typing import (
     Union,
     Optional,
 )
+
+log = logging.getLogger(__name__)
 
 
 class CustomDataset(Dataset):
@@ -54,7 +57,10 @@ class CustomDataset(Dataset):
         if all(map(lambda x: x is None, (names, symbols, nasdaq_index))):
             raise ValueError("all can't be None")
 
-        if nasdaq_index:
+        if isinstance(nasdaq_index, str):
+            log.info(
+                f"trying to create `{self.__class__.__name__}` from `{nasdaq_index}`..."
+            )
             names, symbols = _fetch_names_and_symbols(nasdaq_index)
             save_path = f".data/{nasdaq_index}/"
 

--- a/finq/datautil/nasdaq_requests.py
+++ b/finq/datautil/nasdaq_requests.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-12
-Last updated: 2023-10-12
+Last updated: 2023-10-14
 """
 
 import logging
@@ -33,7 +33,7 @@ import requests
 import pandas as pd
 
 from requests.exceptions import HTTPError
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import (
     Union,
     List,
@@ -71,7 +71,12 @@ def _fetch_names_and_symbols(
 
     url = BASE_URL + index
 
-    today = datetime.today().strftime("%Y-%m-%d")
+    today = datetime.today()
+    if today.isoweekday() in set((6, 7)):
+        today -= timedelta(days=2)
+
+    today = today.strftime("%Y-%m-%d")
+
     params = {
         "tradeDate": f"{today}T00:00:00.000",
         "timeOfDay": "SOD",

--- a/tests/datasets/custom.py
+++ b/tests/datasets/custom.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-11
-Last updated: 2023-10-11
+Last updated: 2023-10-14
 """
 
 import shutil
@@ -31,7 +31,7 @@ import logging
 import numpy as np
 from pathlib import Path
 
-from finq.datasets.custom import CustomDataset
+from finq.datasets import CustomDataset
 
 log = logging.getLogger(__name__)
 SAVE_PATH = ".data/CUSTOM_COOL/"
@@ -112,32 +112,31 @@ class CustomDatasetTest(unittest.TestCase):
             Path(dataset._save_path).is_dir(),
         )
 
-    def test_fetch_index_data(self):
+    def test_fetch_custom_index(self):
         """ """
         dataset = CustomDataset(
             nasdaq_index="OMXS30",
-            save_path=self._save_path,
+            save_path=".data/OMXS30",
             save=False,
         )
+
+        dataset = dataset.fetch_data("1y").fix_missing_data().verify_data()
 
         self.assertEqual(
             dataset._save_path,
             ".data/OMXS30/",
         )
 
-        top_stocks = [
+        tickers = [
             "VOLV-B.ST",
             "ATCO-A.ST",
             "INVE-B.ST",
             "SEB-A.ST",
         ]
 
-        stocks_found_in_index = all([t in dataset.get_tickers() for t in top_stocks])
-        self.assertTrue(stocks_found_in_index)
+        tickers_found_in_index = all([t in dataset.get_tickers() for t in tickers])
+        self.assertTrue(tickers_found_in_index)
 
     def test_all_args_is_none(self):
         """ """
-        try:
-            _ = CustomDataset()
-        except Exception as e:
-            self.assertEqual(type(e), ValueError)
+        self.assertRaises(ValueError, CustomDataset)


### PR DESCRIPTION
Resolve bug when you could not fetch index from NASDAQ on weekends, because there is no information on weekends when the market is closed. Now we check if its a weekend and in that case offsets back two days to a day where we know there is data.