### PR TITLE
fix(nasdaq): correct weekday diff logic in query params

### DIFF
--- a/finq/datasets/dataset.py
+++ b/finq/datasets/dataset.py
@@ -289,24 +289,25 @@ class Dataset(object):
             if diff_dates:
                 missed_data.append(symbol)
 
-            _nan_array = np.full((len(diff_dates), len(df.columns)), np.nan)
-            _df_to_append = pd.DataFrame(
-                _nan_array,
-                columns=df.columns,
-                index=list(diff_dates),
-            )
-            df = (
-                pd.concat(
-                    [
-                        df,
-                        _df_to_append,
-                    ]
+                _nan_array = np.full((len(diff_dates), len(df.columns)), np.nan)
+                _df_to_append = pd.DataFrame(
+                    _nan_array,
+                    columns=df.columns,
+                    index=list(diff_dates),
                 )
-                .sort_index()
-                .interpolate()
-            )
 
-            self._data[symbol] = df
+                df = (
+                    pd.concat(
+                        [
+                            df,
+                            _df_to_append,
+                        ]
+                    )
+                    .sort_index()
+                    .interpolate()
+                )
+
+                self._data[symbol] = df
 
         if missed_data:
             log.debug(

--- a/finq/datautil/nasdaq_requests.py
+++ b/finq/datautil/nasdaq_requests.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-12
-Last updated: 2023-10-14
+Last updated: 2023-10-15
 """
 
 import logging
@@ -74,7 +74,7 @@ def _fetch_names_and_symbols(
 
     url = BASE_URL + index
 
-    weekday_diff = 7 - datetime.today().isoweekday()
+    weekday_diff = max(datetime.today().isoweekday() - 5, 0)
     last_weekday = datetime.date(datetime.today() - timedelta(weekday_diff)).strftime(
         "%Y-%m-%d"
     )


### PR DESCRIPTION
# Description

Update nasdaq_requests.py with working weekday offset logic.
Also reverted a change in dataset.py, earlier we were only attempting to fix missing
data when there was missing data, in earlier PR it was changed to always try attempt fix missing data. Now we don't generate deprecation warning from pandas with trying to
concat empty sequence with df.


## Is this change linked to an existing issue?

- [x] https://github.com/wilhelmagren/finq/issues/29 


## Any other relevant reference?

- https://pythontic.com/datetime/date/isoweekday
