### PR TITLE
build(ci/cd): add pypi publish action with poetry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,4 +32,7 @@ jobs:
         run: poetry build --format wheel
         continue-on-error: false
       - name: Publish to PyPI
-        run: poetry publish --repository pypi
+        uses: JRubics/poetry-publish@v1.17
+        with:
+          pypi_token: ${{ secrets.PYPI_PYFINQ_TOKEN }}
+          ignore_dev_requirements: 'yes'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 </p>
 </div>
 
+![[PyPI - Version](https://img.shields.io/pypi/v/pyfinq)](https://pypi.org/project/pyfinq)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![codecov](https://codecov.io/gh/wilhelmagren/finq/graph/badge.svg?token=9QTX90NYYG)](https://codecov.io/gh/wilhelmagren/finq)
 [![CI](https://github.com/wilhelmagren/finq/actions/workflows/ci.yml/badge.svg)](https://github.com/wilhelmagren/finq/actions/workflows/ci.yml)
@@ -20,7 +21,7 @@
 </div>
 
 ## 🔎 Overview
-The goal of *finq* is to provide an all-in-one Python library for **quantitative portfolio analysis and optimization** on historical and real-time financial data. 
+The goal of *finq* is to provide an all-in-one Python library for **quantitative portfolio analysis and optimization** on historical and real-time financial data.
 
 **NOTE:** Features are currently being determined and developed continuously. The repo is undergoing heavy modifications and could introduce **breaking changes** up until first major release. Current version is **v0.2.0**.
 


### PR DESCRIPTION
# Description

Change publish step, use action, and refer to repo saved pypi token secret.


## Is this change linked to an existing issue?

No, but TODO from earlier PR #28 

- [ ] 


## Any other relevant reference?

- https://github.com/marketplace/actions/publish-python-poetry-package
