### PR TITLE
fix(tests): mock requests during unit testing

### DIFF
--- a/finq/datasets/dataset.py
+++ b/finq/datasets/dataset.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-10
-Last updated: 2023-10-14
+Last updated: 2023-10-15
 """
 
 from __future__ import annotations
@@ -247,6 +247,7 @@ class Dataset(object):
                     ]
                 ]
             )
+
             for date in data[symbol].index:
                 dates[date] = None
 
@@ -353,6 +354,7 @@ class Dataset(object):
             "Low",
             "Close",
         ] = "Close",
+        show: bool = False,
         block: bool = False,
         pause: int = 0,
     ):
@@ -375,9 +377,10 @@ class Dataset(object):
             plt.savefig(save_path)
             log.debug("OK!")
 
-        plt.show(block=block)
-        plt.pause(pause)
-        plt.close()
+        if show:
+            plt.show(block=block)
+            plt.pause(pause)
+            plt.close()
 
     def get_tickers(self) -> List[str]:
         """ """

--- a/tests/datasets/test_custom.py
+++ b/tests/datasets/test_custom.py
@@ -97,13 +97,6 @@ class CustomDatasetTest(unittest.TestCase):
     def test_fetch_visualize(self, mock_ticker_data, mock_ticker_info):
         """ """
 
-        """
-        # This is nasdaq get request we are mocking, would in the future
-        # have the possibility to only mock the get function and not everything...
-        mock_get.return_value.names = ['LOLHAHA']  # self._names
-        mock_get.return_value.symbols = ['XDSYMBOL.ST']  #self._symbols
-        """
-
         mock_ticker_info.return_value = {
             "funny info about option": "yes very much",
         }

--- a/tests/datasets/test_omxs30.py
+++ b/tests/datasets/test_omxs30.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-12
-Last updated: 2023-10-12
+Last updated: 2023-10-15
 """
 
 import shutil
@@ -38,7 +38,10 @@ SAVE_PATH = ".data/OMXS30/"
 
 
 class OMXS30Test(unittest.TestCase):
-    """ """
+    """This is the only index that we will not mock. This is relatively small enough
+    so we are not generating a lot of traffic when testing without mock. For all other
+    tests, we should mock.
+    """
 
     def setUp(self):
         """ """
@@ -57,6 +60,7 @@ class OMXS30Test(unittest.TestCase):
 
     def test_fetch_data_no_save(self):
         """ """
+
         dataset = OMXS30(save_path=self._save_path, save=False)
 
         dataset = dataset.fetch_data("1y").fix_missing_data().verify_data()


### PR DESCRIPTION
# Description

Mock functionality on tests. We allow the OMXS30 test to NOT BE MOCKED ON NASDAQ. This is a relatively small index so we can generate the traffic. However, all other tests should/are mocked (yfinance get requests).

Also, add show bool arg to dataset.visualize() func to avoid warnings during test

## Is this change linked to an existing issue?

- [x] #14  


## Any other relevant reference?

- https://stackoverflow.com/questions/11836436/how-to-mock-a-readonly-property-with-mock
- https://www.fugue.co/blog/2016-02-11-python-mocking-101
- https://github.com/ranaroussi/yfinance/blob/308e58b914a065f33402bdcb3ed72e2b2d881f64/yfinance/base.py#L435
