### PR TITLE
feat(cache): use CachedRateLimiter session for NASDAQ requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         continue-on-error: false
 
   format:
-    name: Black formatting
+    name: Black format
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,9 @@ format:
 lint:
 	poetry run ruff check finq tests --fix
 
+.PHONY: static-check
+static-check:
+	poetry run mypy finq
+
 .PHONY: clean-test
 clean-test: clean test

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 ## 🔎 Overview
 The goal of *finq* is to provide an all-in-one Python library for **quantitative portfolio analysis and optimization** on historical and real-time financial data.
 
-**NOTE:** Features are currently being determined and developed continuously. The repo is undergoing heavy modifications and could introduce **breaking changes** up until first major release. Current version is **v0.2.0**.
+**NOTE:** Features are currently being determined and developed continuously. The repo is undergoing heavy modifications and could introduce **breaking changes** up until first major release. Current version is **v0.2.1**.
 
 ## 📦 Installation
 Either clone this repository and perform a local install with [poetry](https://github.com/python-poetry/poetry/tree/master) accordingly
@@ -48,7 +48,7 @@ from finq.datasets import CustomDataset
 names = ["Alfa Laval", "Boliden", "SEB A", "Sv. Handelsbanken A"]
 symbols = ["ALFA.ST", "BOL.ST", "SEB-A.ST", "SHB-A.ST"]
 
-dataset = CustomDataset(names, symbols, save=True)
+dataset = CustomDataset(names, symbols, market="OMX", save=True)
 dataset.fetch_data("3y") \
     .fix_missing_data() \
     .verify_data()
@@ -64,7 +64,7 @@ call the function `.run(period)` which performs the three steps the above cell d
 ```python
 from finq.datasets import CustomDataset
 
-dataset = CustomDataset(nasdaq_index='NDX', save=False)
+dataset = CustomDataset(index_name='NDX', market="NASDAQ", save=False)
 dataset.run("1y")
 
 closing_prices = dataset.as_numpy("Close")

--- a/finq/datasets/custom.py
+++ b/finq/datasets/custom.py
@@ -22,11 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-11
-Last updated: 2023-10-13
+Last updated: 2023-10-16
 """
 
 from finq.datasets.dataset import Dataset
-from finq.datautil import _fetch_names_and_symbols
 
 from pathlib import Path
 from typing import (
@@ -45,22 +44,33 @@ class CustomDataset(Dataset):
         names: Optional[List[str]] = None,
         symbols: Optional[List[str]] = None,
         *,
-        nasdaq_index: Optional[str] = None,
+        index_name: Optional[str] = None,
+        market: Optional[str] = None,
         save_path: Union[str, Path] = ".data/CUSTOM/",
         **kwargs: Dict,
     ):
         """ """
 
-        if all(map(lambda x: x is None, (names, symbols, nasdaq_index))):
-            raise ValueError("all can't be None")
+        if all(map(lambda x: x is None, (names, symbols, index_name))):
+            raise ValueError(
+                "All values can't be None. You need to either specify "
+                "`index_name` or `names` and `symbols`. If you specify an "
+                "unknown index name, we will try and find it on NASDAQ, but might fail."
+            )
 
-        if nasdaq_index:
-            names, symbols = _fetch_names_and_symbols(nasdaq_index)
-            save_path = f".data/{nasdaq_index}/"
+        if index_name:
+            if not market:
+                raise ValueError(
+                    "When defining a `CustomDataset` you need to specify what market "
+                    "that you intend to fetch the ticker symbols from, e.g., `OMX`."
+                )
+            save_path = f".data/{index_name}/"
 
         super(CustomDataset, self).__init__(
             names,
             symbols,
+            index_name=index_name,
+            market=market,
             save_path=save_path,
             **kwargs,
         )

--- a/finq/datasets/ndx.py
+++ b/finq/datasets/ndx.py
@@ -21,14 +21,34 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-File created: 2023-10-10
+File created: 2023-10-16
 Last updated: 2023-10-16
 """
 
-from .custom import CustomDataset  # noqa
-from .dataset import Dataset  # noqa
-from .ndx import NDX  # noqa
-from .omxs30 import OMXS30  # noqa
-from .omxsbesgni import OMXSBESGNI  # noqa
-from .omxspi import OMXSPI  # noqa
-from .snp500 import SNP500  # noqa
+from finq.datasets.dataset import Dataset
+
+from pathlib import Path
+from typing import (
+    Any,
+    Dict,
+    Union,
+)
+
+
+class NDX(Dataset):
+    """ """
+
+    def __init__(
+        self,
+        *,
+        save_path: Union[str, Path] = ".data/NDX/",
+        **kwargs: Dict[str, Any],
+    ):
+        """ """
+
+        super(NDX, self).__init__(
+            index_name="NDX",
+            market="NASDAQ",
+            save_path=save_path,
+            **kwargs,
+        )

--- a/finq/datasets/omxs30.py
+++ b/finq/datasets/omxs30.py
@@ -22,11 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-10
-Last updated: 2023-10-12
+Last updated: 2023-10-16
 """
 
 from finq.datasets.dataset import Dataset
-from finq.datautil import _fetch_names_and_symbols
 
 from pathlib import Path
 from typing import (
@@ -46,11 +45,9 @@ class OMXS30(Dataset):
     ):
         """ """
 
-        omxs30_names, omxs30_symbols = _fetch_names_and_symbols("OMXS30")
-
         super(OMXS30, self).__init__(
-            omxs30_names,
-            omxs30_symbols,
+            index_name="OMXS30",
+            market="OMX",
             save_path=save_path,
             **kwargs,
         )

--- a/finq/datasets/omxsbesgni.py
+++ b/finq/datasets/omxsbesgni.py
@@ -21,14 +21,33 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-File created: 2023-10-10
+File created: 2023-10-16
 Last updated: 2023-10-16
 """
 
-from .custom import CustomDataset  # noqa
-from .dataset import Dataset  # noqa
-from .ndx import NDX  # noqa
-from .omxs30 import OMXS30  # noqa
-from .omxsbesgni import OMXSBESGNI  # noqa
-from .omxspi import OMXSPI  # noqa
-from .snp500 import SNP500  # noqa
+from finq.datasets.dataset import Dataset
+
+from pathlib import Path
+from typing import (
+    Dict,
+    Union,
+)
+
+
+class OMXSBESGNI(Dataset):
+    """OMX Stockholm Benchmark ESG Responsible Net Index."""
+
+    def __init__(
+        self,
+        *,
+        save_path: Union[str, Path] = ".data/OMXSBESGNI/",
+        **kwargs: Dict,
+    ):
+        """ """
+
+        super(OMXSBESGNI, self).__init__(
+            index_name="OMXSBESGNI",
+            market="OMX",
+            save_path=save_path,
+            **kwargs,
+        )

--- a/finq/datasets/omxspi.py
+++ b/finq/datasets/omxspi.py
@@ -22,11 +22,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-13
-Last updated: 2023-10-13
+Last updated: 2023-10-16
 """
 
 from finq.datasets.dataset import Dataset
-from finq.datautil import _fetch_names_and_symbols
 
 from pathlib import Path
 from typing import (
@@ -46,11 +45,9 @@ class OMXSPI(Dataset):
     ):
         """ """
 
-        omxspi_names, omxspi_symbols = _fetch_names_and_symbols("OMXSPI")
-
         super(OMXSPI, self).__init__(
-            omxspi_names,
-            omxspi_symbols,
+            index_name="OMXSPI",
+            market="OMX",
             save_path=save_path,
             **kwargs,
         )

--- a/finq/datasets/snp500.py
+++ b/finq/datasets/snp500.py
@@ -1060,6 +1060,7 @@ class SNP500(Dataset):
         super(SNP500, self).__init__(
             snp500_names,
             snp500_symbols,
+            market="NASDAQ",
             save_path=save_path,
             **kwargs,
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -937,6 +937,52 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.6.0"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "mypy-1.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:091f53ff88cb093dcc33c29eee522c087a438df65eb92acd371161c1f4380ff0"},
+    {file = "mypy-1.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:eb7ff4007865833c470a601498ba30462b7374342580e2346bf7884557e40531"},
+    {file = "mypy-1.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49499cf1e464f533fc45be54d20a6351a312f96ae7892d8e9f1708140e27ce41"},
+    {file = "mypy-1.6.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4c192445899c69f07874dabda7e931b0cc811ea055bf82c1ababf358b9b2a72c"},
+    {file = "mypy-1.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:3df87094028e52766b0a59a3e46481bb98b27986ed6ded6a6cc35ecc75bb9182"},
+    {file = "mypy-1.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c8835a07b8442da900db47ccfda76c92c69c3a575872a5b764332c4bacb5a0a"},
+    {file = "mypy-1.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:24f3de8b9e7021cd794ad9dfbf2e9fe3f069ff5e28cb57af6f873ffec1cb0425"},
+    {file = "mypy-1.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:856bad61ebc7d21dbc019b719e98303dc6256cec6dcc9ebb0b214b81d6901bd8"},
+    {file = "mypy-1.6.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:89513ddfda06b5c8ebd64f026d20a61ef264e89125dc82633f3c34eeb50e7d60"},
+    {file = "mypy-1.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:9f8464ed410ada641c29f5de3e6716cbdd4f460b31cf755b2af52f2d5ea79ead"},
+    {file = "mypy-1.6.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:971104bcb180e4fed0d7bd85504c9036346ab44b7416c75dd93b5c8c6bb7e28f"},
+    {file = "mypy-1.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab98b8f6fdf669711f3abe83a745f67f50e3cbaea3998b90e8608d2b459fd566"},
+    {file = "mypy-1.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a69db3018b87b3e6e9dd28970f983ea6c933800c9edf8c503c3135b3274d5ad"},
+    {file = "mypy-1.6.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:dccd850a2e3863891871c9e16c54c742dba5470f5120ffed8152956e9e0a5e13"},
+    {file = "mypy-1.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:f8598307150b5722854f035d2e70a1ad9cc3c72d392c34fffd8c66d888c90f17"},
+    {file = "mypy-1.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fea451a3125bf0bfe716e5d7ad4b92033c471e4b5b3e154c67525539d14dc15a"},
+    {file = "mypy-1.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e28d7b221898c401494f3b77db3bac78a03ad0a0fff29a950317d87885c655d2"},
+    {file = "mypy-1.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4b7a99275a61aa22256bab5839c35fe8a6887781862471df82afb4b445daae6"},
+    {file = "mypy-1.6.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7469545380dddce5719e3656b80bdfbb217cfe8dbb1438532d6abc754b828fed"},
+    {file = "mypy-1.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:7807a2a61e636af9ca247ba8494031fb060a0a744b9fee7de3a54bed8a753323"},
+    {file = "mypy-1.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d2dad072e01764823d4b2f06bc7365bb1d4b6c2f38c4d42fade3c8d45b0b4b67"},
+    {file = "mypy-1.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b19006055dde8a5425baa5f3b57a19fa79df621606540493e5e893500148c72f"},
+    {file = "mypy-1.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:31eba8a7a71f0071f55227a8057468b8d2eb5bf578c8502c7f01abaec8141b2f"},
+    {file = "mypy-1.6.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8e0db37ac4ebb2fee7702767dfc1b773c7365731c22787cb99f507285014fcaf"},
+    {file = "mypy-1.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:c69051274762cccd13498b568ed2430f8d22baa4b179911ad0c1577d336ed849"},
+    {file = "mypy-1.6.0-py3-none-any.whl", hash = "sha256:9e1589ca150a51d9d00bb839bfeca2f7a04f32cd62fad87a847bc0818e15d7dc"},
+    {file = "mypy-1.6.0.tar.gz", hash = "sha256:4f3d27537abde1be6d5f2c96c29a454da333a2a271ae7d5bc7110e6d4b7beb3f"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=4.1.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+reports = ["lxml"]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.0.0"
 description = "Type system extensions for programs checked with the mypy type checker."
@@ -1689,4 +1735,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "ddc34b7ac04317057696b2e313d194527e2204dcb3d16cc9daaa4c5c8983ad38"
+content-hash = "139fb00cb7dc0c42d4e498f6398976aad2a6e41625039fec043acf946a765208"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ pyclean = "^2.7.5"
 black = "^23.9.1"
 ruff = "^0.0.292"
 pre-commit = "^3.5.0"
+mypy = "^1.6.0"
 
 
 [build-system]
@@ -84,3 +85,7 @@ ignore = [
 [tool.black]
 target-version = [ "py310" ]
 line-length = 89
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pyfinq"
-version = "0.2.0"
-description = "🔬 Enabling seamless quantitative finance solutions."
+version = "0.2.1"
+description = "🔬 Quantitative analysis and management for financial applications. "
 authors = [
     "Wilhelm Ågren <wilhelmagren98@gmail.com>",
 ]

--- a/tests/datasets/test_custom.py
+++ b/tests/datasets/test_custom.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-11
-Last updated: 2023-10-15
+Last updated: 2023-10-16
 """
 
 import os
@@ -78,6 +78,7 @@ class CustomDatasetTest(unittest.TestCase):
 
         self._names = names
         self._symbols = symbols
+        self._market = "OMX"
         self._save_path = SAVE_PATH
 
     def tearDown(self):
@@ -102,6 +103,7 @@ class CustomDatasetTest(unittest.TestCase):
         dataset = CustomDataset(
             self._names,
             self._symbols,
+            market=self._market,
             save_path=self._save_path,
             save=False,
         )
@@ -130,6 +132,7 @@ class CustomDatasetTest(unittest.TestCase):
         dataset = CustomDataset(
             self._names,
             self._symbols,
+            market=self._market,
             save_path=self._save_path,
             save=False,
         )
@@ -158,6 +161,7 @@ class CustomDatasetTest(unittest.TestCase):
         dataset = CustomDataset(
             self._names,
             self._symbols,
+            market=self._market,
             save_path=self._save_path,
             save=True,
         )
@@ -195,7 +199,8 @@ class CustomDatasetTest(unittest.TestCase):
         mock_ticker_data.return_value = df
 
         dataset = CustomDataset(
-            nasdaq_index="OMXS30",
+            index_name="OMXS30",
+            market=self._market,
             save=False,
         )
 
@@ -231,6 +236,7 @@ class CustomDatasetTest(unittest.TestCase):
         dataset = CustomDataset(
             self._names,
             self._symbols,
+            market=self._market,
             save_path=self._save_path,
             save=True,
         )
@@ -246,6 +252,7 @@ class CustomDatasetTest(unittest.TestCase):
         d = CustomDataset(
             self._names,
             self._symbols,
+            market=self._market,
             save_path=self._save_path,
             save=False,
         )

--- a/tests/datasets/test_ndx.py
+++ b/tests/datasets/test_ndx.py
@@ -1,0 +1,106 @@
+"""
+MIT License
+
+Copyright (c) 2023 Wilhelm Ågren
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+File created: 2023-10-16
+Last updated: 2023-10-16
+"""
+
+import shutil
+import unittest
+import pandas as pd
+import numpy as np
+from unittest.mock import patch, PropertyMock
+from pathlib import Path
+from typing import List
+from datetime import (
+    datetime,
+    timedelta,
+)
+
+from finq.datasets import NDX
+
+SAVE_PATH = ".data/NDX/"
+
+
+def _random_df(cols: List[str]) -> pd.DataFrame:
+    """ """
+    date_today = datetime.now()
+    days = pd.date_range(date_today, date_today + timedelta(30), freq="D")
+
+    data = np.random.uniform(low=20, high=500, size=(len(days), len(cols)))
+    df = pd.DataFrame(data, columns=cols, index=days)
+    return df
+
+
+class NDXTest(unittest.TestCase):
+    """ """
+
+    def setUp(self):
+        """ """
+        self._save_path = SAVE_PATH
+
+    def tearDown(self):
+        """ """
+        path = Path(SAVE_PATH)
+
+        if path.is_dir():
+            shutil.rmtree(SAVE_PATH)
+
+    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.history")
+    def test_fetch_then_load(self, mock_ticker_data, mock_ticker_info):
+        """ """
+
+        mock_ticker_info.return_value = {
+            "funny info about option": "yes very much",
+        }
+
+        df = _random_df(["Open", "High", "Low", "Close"])
+        mock_ticker_data.return_value = df
+
+        d = NDX(save=True)
+        d.run("1y")
+
+        info_path = Path(self._save_path) / "info"
+        data_path = Path(self._save_path) / "data"
+
+        self.assertTrue(info_path.is_dir())
+        self.assertTrue(data_path.is_dir())
+
+        n = NDX(save=False)
+        n.fetch_data("1y")
+
+        self.assertEqual(
+            d.get_tickers(),
+            n.get_tickers(),
+        )
+
+        self.assertEqual(
+            d.as_numpy("High").shape,
+            n.as_numpy("High").shape,
+        )
+
+        self.assertEqual(
+            len(d["AMD"].index.values),
+            len(n.get_data()["AMD"].index.values),
+        )

--- a/tests/datasets/test_omxs30.py
+++ b/tests/datasets/test_omxs30.py
@@ -22,12 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-12
-Last updated: 2023-10-15
+Last updated: 2023-10-16
 """
 
 import shutil
 import unittest
 import numpy as np
+import pandas as pd
 from pathlib import Path
 
 from finq.datasets import OMXS30
@@ -58,7 +59,9 @@ class OMXS30Test(unittest.TestCase):
         dataset = OMXS30(save_path=self._save_path, save=False)
 
         dataset = dataset.fetch_data("1y").fix_missing_data().verify_data()
+        df = dataset["SHB-A.ST"]
 
+        self.assertTrue(isinstance(df, pd.DataFrame))
         self.assertTrue(isinstance(dataset.as_numpy(), np.ndarray))
 
     def test_fetch_data_save(self):

--- a/tests/datasets/test_omxsbesgni.py
+++ b/tests/datasets/test_omxsbesgni.py
@@ -1,0 +1,106 @@
+"""
+MIT License
+
+Copyright (c) 2023 Wilhelm Ågren
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+File created: 2023-10-16
+Last updated: 2023-10-16
+"""
+
+import shutil
+import unittest
+import pandas as pd
+import numpy as np
+from unittest.mock import patch, PropertyMock
+from pathlib import Path
+from typing import List
+from datetime import (
+    datetime,
+    timedelta,
+)
+
+from finq.datasets import OMXSBESGNI
+
+SAVE_PATH = ".data/OMXSBESGNI/"
+
+
+def _random_df(cols: List[str]) -> pd.DataFrame:
+    """ """
+    date_today = datetime.now()
+    days = pd.date_range(date_today, date_today + timedelta(30), freq="D")
+
+    data = np.random.uniform(low=20, high=500, size=(len(days), len(cols)))
+    df = pd.DataFrame(data, columns=cols, index=days)
+    return df
+
+
+class OMXSBESGNITest(unittest.TestCase):
+    """ """
+
+    def setUp(self):
+        """ """
+        self._save_path = SAVE_PATH
+
+    def tearDown(self):
+        """ """
+        path = Path(SAVE_PATH)
+
+        if path.is_dir():
+            shutil.rmtree(SAVE_PATH)
+
+    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.history")
+    def test_fetch_then_load(self, mock_ticker_data, mock_ticker_info):
+        """ """
+
+        mock_ticker_info.return_value = {
+            "funny info about option": "yes very much",
+        }
+
+        df = _random_df(["Open", "High", "Low", "Close"])
+        mock_ticker_data.return_value = df
+
+        d = OMXSBESGNI(save=True)
+        d.run("1y")
+
+        info_path = Path(self._save_path) / "info"
+        data_path = Path(self._save_path) / "data"
+
+        self.assertTrue(info_path.is_dir())
+        self.assertTrue(data_path.is_dir())
+
+        n = OMXSBESGNI(save=False)
+        n.fetch_data("1y")
+
+        self.assertEqual(
+            d.get_tickers(),
+            n.get_tickers(),
+        )
+
+        self.assertEqual(
+            d.as_numpy("High").shape,
+            n.as_numpy("High").shape,
+        )
+
+        self.assertEqual(
+            len(d["SWED-A.ST"].index.values),
+            len(n.get_data()["SWED-A.ST"].index.values),
+        )

--- a/tests/datautil/test_nasdaq_requests.py
+++ b/tests/datautil/test_nasdaq_requests.py
@@ -22,17 +22,27 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-13
-Last updated: 2023-10-13
+Last updated: 2023-10-16
 """
 
 import unittest
+import os
+from zipfile import BadZipFile
 
 from finq.datautil import _fetch_names_and_symbols
+
+WRONG_INDEX_NAME = "KEBABXD"
 
 
 class NasdaqRequestsTest(unittest.TestCase):
     """ """
 
+    def tearDown(self):
+        """ """
+        for file in os.listdir("."):
+            if WRONG_INDEX_NAME in file:
+                os.remove(file)
+
     def test_not_supported_index(self):
         """ """
-        self.assertRaises(ValueError, _fetch_names_and_symbols, "KEBABXD")
+        self.assertRaises(BadZipFile, _fetch_names_and_symbols, WRONG_INDEX_NAME)


### PR DESCRIPTION
# Description

Add session to nasdaq requests, thus caching the index components xlsx we otherwise download. Also add proxy setting to yfinance.history and session.get,

improve testing

## Is this change linked to an existing issue?


- [x] https://github.com/wilhelmagren/finq/issues/37


## Any other relevant reference?

*If changes are inspired by other code, please paste a link to the reference.*

- N/A
