### PR TITLE
docs(finq): docstrings for Dataset, refactor, implement path utils

### DIFF
--- a/finq/__init__.py
+++ b/finq/__init__.py
@@ -28,6 +28,7 @@ Last updated: 2023-10-21
 from finq import datasets  # noqa
 from finq import datautil  # noqa
 from .asset import Asset  # noqa
+from .exceptions import *  # noqa
 from .portfolio import Portfolio  # noqa
 from .__version__ import __version__  # noqa
 

--- a/finq/datasets/custom.py
+++ b/finq/datasets/custom.py
@@ -22,55 +22,73 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-11
-Last updated: 2023-10-16
+Last updated: 2023-10-21
 """
 
+from finq.exceptions import InvalidCombinationOfArgumentsError
 from finq.datasets.dataset import Dataset
 
-from pathlib import Path
 from typing import (
+    Any,
     List,
     Dict,
-    Union,
     Optional,
 )
 
 
 class CustomDataset(Dataset):
-    """ """
+    """
+    An implementation of the base ``Dataset`` class which allows the user to define a
+    custom dataset based on either: a list of names and ticker symbols, or the name of
+    an index and the market it is available on.
+
+    Parameters
+    ----------
+    names : list | None
+        The names of the financial assets to create a dataset with.
+    symbols : list | None
+        The ticker symbols corresponding to the names of the financial assets.
+    market : str | None
+        The name of the market to fetch the historical price data from.
+    index_name : str | None
+        The name of the financial index to get ticker symbols and names from.
+    dataset_name : str
+        The name of the ``Dataset`` class instance.
+
+    """
 
     def __init__(
         self,
         names: Optional[List[str]] = None,
         symbols: Optional[List[str]] = None,
         *,
-        index_name: Optional[str] = None,
         market: Optional[str] = None,
-        save_path: Union[str, Path] = ".data/CUSTOM/",
-        **kwargs: Dict,
-    ):
+        index_name: Optional[str] = None,
+        dataset_name: Optional[str] = "custom",
+        **kwargs: Dict[str, Any],
+    ) -> Optional[InvalidCombinationOfArgumentsError]:
         """ """
 
         if all(map(lambda x: x is None, (names, symbols, index_name))):
-            raise ValueError(
-                "All values can't be None. You need to either specify "
-                "`index_name` or `names` and `symbols`. If you specify an "
-                "unknown index name, we will try and find it on NASDAQ, but might fail."
+            raise InvalidCombinationOfArgumentsError(
+                "All values can't be None. You need to either specify `index_name` or "
+                "`names` and `symbols`. If you specify an unknown index name, we will "
+                "try and find it on NASDAQ, but might fail."
             )
 
         if index_name:
             if not market:
-                raise ValueError(
+                raise InvalidCombinationOfArgumentsError(
                     "When defining a `CustomDataset` you need to specify what market "
                     "that you intend to fetch the ticker symbols from, e.g., `OMX`."
                 )
-            save_path = f".data/{index_name}/"
+            dataset_name = index_name
 
         super(CustomDataset, self).__init__(
             names,
             symbols,
-            index_name=index_name,
             market=market,
-            save_path=save_path,
+            index_name=index_name,
+            dataset_name=dataset_name,
             **kwargs,
         )

--- a/finq/datasets/dataset.py
+++ b/finq/datasets/dataset.py
@@ -62,32 +62,39 @@ log = logging.getLogger(__name__)
 
 class Dataset(object):
     """
-    A collection of ticker symbols and their historical price data.
+    A collection of ticker symbols and their historical price data. Fetches information
+    and prices from Yahoo! Finance and optionally saves them to a local path for later
+    use. Supports fixing missing values by interpolating ``NaN`` and verifying the
+    integrity of the fetched data.
 
     Parameters
     ----------
     names : list | None
-
+        The names of the financial assets to create a dataset with.
     symbols : list | None
-
+        The ticker symbols corresponding to the names of the financial assets.
     market : str
-
+        The name of the market to fetch the historical price data from.
+        Defaults to ``OMX``.
     index_name : str | None
-
+        The name of the financial index to get ticker symbols and names from.
     proxy : str | None
-
+        The name of the proxy url to use for REST requests.
     n_requests : int
-
+        The max number of requests to perform per ``t_interval``. Defaults to ``5``.
     t_interval : int
-
+        The time interval (in seconds) to use with the ``CachedRateLimiter``.
+        Defaults to ``1``.
     save : bool
-
+        Wether or not to save the fetched data to a local file path.
     save_path : Path | str
-
+        The local file path to potentially save any fetched data to.
+        Defaults to ``.data/dataset/``.
+    dataset_name : str
+        The name of the ``Dataset`` class instance.
     separator : str
-
-    Attributes
-    ----------
+        The csv separator to use when loading and saving any ``pd.DataFrame``.
+        Defaults to ``;``.
 
     """
 
@@ -102,7 +109,8 @@ class Dataset(object):
         n_requests: int = 5,
         t_interval: int = 1,
         save: bool = False,
-        save_path: Union[Path, str] = ".data/dataset/",
+        save_path: Union[Path, str] = Path.home(),
+        dataset_name: str = "dataset",
         separator: str = ";",
     ) -> Dataset:
         """ """
@@ -162,7 +170,8 @@ class Dataset(object):
         self._index_name = index_name
 
         self._save = save
-        self._save_path = Path(save_path)
+        self._save_path = Path(save_path) / ".data" / dataset_name
+        self._dataset_name = dataset_name
         self._separator = separator
 
     def __getitem__(self, key: str) -> Optional[pd.DataFrame]:

--- a/finq/datasets/ndx.py
+++ b/finq/datasets/ndx.py
@@ -22,33 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-16
-Last updated: 2023-10-16
+Last updated: 2023-10-21
 """
 
 from finq.datasets.dataset import Dataset
 
-from pathlib import Path
 from typing import (
     Any,
     Dict,
-    Union,
 )
 
 
 class NDX(Dataset):
     """ """
 
-    def __init__(
-        self,
-        *,
-        save_path: Union[str, Path] = ".data/NDX/",
-        **kwargs: Dict[str, Any],
-    ):
+    def __init__(self, **kwargs: Dict[str, Any]):
         """ """
 
         super(NDX, self).__init__(
-            index_name="NDX",
             market="NASDAQ",
-            save_path=save_path,
+            index_name="NDX",
+            dataset_name="NDX",
             **kwargs,
         )

--- a/finq/datasets/omxs30.py
+++ b/finq/datasets/omxs30.py
@@ -22,32 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-10
-Last updated: 2023-10-16
+Last updated: 2023-10-21
 """
 
 from finq.datasets.dataset import Dataset
 
-from pathlib import Path
 from typing import (
+    Any,
     Dict,
-    Union,
 )
 
 
 class OMXS30(Dataset):
     """ """
 
-    def __init__(
-        self,
-        *,
-        save_path: Union[str, Path] = ".data/OMXS30/",
-        **kwargs: Dict,
-    ):
+    def __init__(self, **kwargs: Dict[str, Any]):
         """ """
 
         super(OMXS30, self).__init__(
-            index_name="OMXS30",
             market="OMX",
-            save_path=save_path,
+            index_name="OMXS30",
+            dataset_name="OMXS30",
             **kwargs,
         )

--- a/finq/datasets/omxsbesgni.py
+++ b/finq/datasets/omxsbesgni.py
@@ -22,32 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-16
-Last updated: 2023-10-16
+Last updated: 2023-10-21
 """
 
 from finq.datasets.dataset import Dataset
 
-from pathlib import Path
 from typing import (
+    Any,
     Dict,
-    Union,
 )
 
 
 class OMXSBESGNI(Dataset):
     """OMX Stockholm Benchmark ESG Responsible Net Index."""
 
-    def __init__(
-        self,
-        *,
-        save_path: Union[str, Path] = ".data/OMXSBESGNI/",
-        **kwargs: Dict,
-    ):
+    def __init__(self, **kwargs: Dict[str, Any]):
         """ """
 
         super(OMXSBESGNI, self).__init__(
-            index_name="OMXSBESGNI",
             market="OMX",
-            save_path=save_path,
+            index_name="OMXSBESGNI",
+            dataset_name="OMXSBESGNI",
             **kwargs,
         )

--- a/finq/datasets/omxspi.py
+++ b/finq/datasets/omxspi.py
@@ -22,32 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-13
-Last updated: 2023-10-16
+Last updated: 2023-10-21
 """
 
 from finq.datasets.dataset import Dataset
 
-from pathlib import Path
 from typing import (
+    Any,
     Dict,
-    Union,
 )
 
 
 class OMXSPI(Dataset):
     """ """
 
-    def __init__(
-        self,
-        *,
-        save_path: Union[str, Path] = ".data/OMXSPI/",
-        **kwargs: Dict,
-    ):
+    def __init__(self, **kwargs: Dict[str, Any]):
         """ """
 
         super(OMXSPI, self).__init__(
-            index_name="OMXSPI",
             market="OMX",
-            save_path=save_path,
+            index_name="OMXSPI",
+            dataset_name="OMXSPI",
             **kwargs,
         )

--- a/finq/datasets/snp500.py
+++ b/finq/datasets/snp500.py
@@ -22,15 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-11
-Last updated: 2023-10-12
+Last updated: 2023-10-21
 """
 
 from finq.datasets.dataset import Dataset
 
-from pathlib import Path
 from typing import (
+    Any,
     Dict,
-    Union,
 )
 
 snp500_names = [
@@ -1049,18 +1048,13 @@ snp500_symbols = [
 class SNP500(Dataset):
     """ """
 
-    def __init__(
-        self,
-        *,
-        save_path: Union[str, Path] = ".data/SNP500/",
-        **kwargs: Dict,
-    ):
+    def __init__(self, **kwargs: Dict[str, Any]):
         """ """
 
         super(SNP500, self).__init__(
             snp500_names,
             snp500_symbols,
             market="NASDAQ",
-            save_path=save_path,
+            dataset_name="SNP500",
             **kwargs,
         )

--- a/finq/datautil/__init__.py
+++ b/finq/datautil/__init__.py
@@ -22,8 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-12
-Last updated: 2023-10-12
+Last updated: 2023-10-21
 """
 
 from .cached_rate_limiter import CachedRateLimiter  # noqa
-from .nasdaq_requests import _fetch_names_and_symbols  # noqa
+from .path_utils import (
+    all_tickers_saved,  # noqa
+    default_finq_cache_path,  # noqa
+    default_finq_save_path,  # noqa
+    setup_finq_save_path,  # noqa
+)
+from .nasdaq_utils import fetch_names_and_symbols  # noqa

--- a/finq/datautil/nasdaq_utils.py
+++ b/finq/datautil/nasdaq_utils.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-12
-Last updated: 2023-10-20
+Last updated: 2023-10-21
 """
 
 import logging
@@ -38,10 +38,10 @@ from datetime import (
     timedelta,
 )
 from typing import (
+    Any,
     Union,
     List,
     Dict,
-    Literal,
     Tuple,
     Optional,
     Callable,
@@ -59,15 +59,15 @@ IMPLEMENTED_INDEX = (
 )
 
 
-def _fetch_names_and_symbols(
+def fetch_names_and_symbols(
     index: str,
     *,
     session: Optional[requests.Session] = None,
-    query_params: Dict = {},
-    headers: Dict = {},
-    market: Literal["NASDAQ", "OMX"] = "OMX",
+    query_params: Dict[Any, Any] = {},
+    headers: Dict[Any, Any] = {},
+    market: str = "OMX",
     filter_symbols: Callable = lambda s: s,
-) -> Union[Exception, Tuple[List[str], List[str]]]:
+) -> Union[HTTPError, Tuple[List[str], List[str]]]:
     """ """
 
     if index not in IMPLEMENTED_INDEX:
@@ -126,11 +126,6 @@ def _fetch_names_and_symbols(
 
     os.remove(tmp_xlsx_path)
     log.debug("OK!")
-
-    if market == "OMX":
-
-        def filter_symbols(s):
-            return s.replace(" ", "-") + ".ST"
 
     names = df["Company Name"].tolist()
     symbols = list(

--- a/finq/datautil/path_utils.py
+++ b/finq/datautil/path_utils.py
@@ -1,0 +1,150 @@
+"""
+MIT License
+
+Copyright (c) 2023 Wilhelm Ågren
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+File created: 2023-10-21
+Last updated: 2023-10-21
+"""
+
+import logging
+from pathlib import Path
+from typing import (
+    List,
+    Optional,
+    Union,
+)
+
+log = logging.getLogger(__name__)
+
+
+def default_finq_cache_path() -> Path:
+    """
+    Get the default absolute path to the ``finq`` http response cache.
+
+    Returns
+    -------
+    Path
+        The absolute path to the cache.
+
+    """
+
+    return Path.home() / ".finq" / "http_cache"
+
+
+def default_finq_save_path() -> Path:
+    """
+    Get the default absolute path to the ``finq`` data directory. Default behaviour
+    is a path to the home directory of the user.
+
+    Returns
+    -------
+    Path
+        The absolute path to the ``finq`` data directory.
+
+    """
+
+    return Path.home() / ".finq" / "data"
+
+
+def all_tickers_saved(path: Union[Path, str], tickers: List[str]) -> bool:
+    """
+    Check whether or not all tickers have been saved locally.
+
+    Parameters
+    ----------
+    path : Path | str
+        The local path to the potentially saved data for a ``Dataset``.
+    tickers : list
+        The list of ticker symbols to try and find saved files for.
+
+    Returns
+    -------
+    bool
+        ``True`` if all ticker files exist locally, else ``False``.
+
+    """
+
+    if isinstance(path, str):
+        path = Path(path)
+
+    info_path = path / "info"
+    data_path = path / "data"
+
+    if info_path.is_dir():
+        for ticker in tickers:
+            if not Path(info_path / f"{ticker}.json").exists():
+                return False
+
+    if data_path.is_dir():
+        for ticker in tickers:
+            if not Path(data_path / f"{ticker}.csv").exists():
+                return False
+
+    if (not info_path.is_dir()) or (not data_path.is_dir()):
+        return False
+
+    return True
+
+
+def setup_finq_save_path(path: Union[Path, str]) -> Optional[NotADirectoryError]:
+    """
+    Create the local paths required so save any fetched ticker info and data.
+
+    Parameters
+    ----------
+    path : Path | str
+        The local path of a ``Dataset`` where the required paths should be created.
+
+    Raises
+    ------
+    NotADirectoryError
+        If the local save path already exists but is not a directory.
+
+    """
+
+    if isinstance(path, str):
+        path = Path(path)
+
+    log.info(f"setting up {path} for data saving...")
+    if path.exists():
+        if not path.is_dir():
+            raise NotADirectoryError(
+                "Your specified path to save fetched data to is not a directory, "
+                "maybe you provided a path to a file that you want to create?"
+            )
+
+        log.warning(f"path {path} already exists, will overwrite existing data...")
+
+    log.info(f"creating {path}...")
+    path.mkdir(parents=True, exist_ok=True)
+    log.info("OK!")
+
+    info_path = path / "info"
+    data_path = path / "data"
+
+    log.info(f"creating path {info_path}...")
+    info_path.mkdir(parents=False, exist_ok=True)
+    log.info("OK!")
+
+    log.info(f"creating path {data_path}...")
+    data_path.mkdir(parents=False, exist_ok=True)
+    log.info("OK!")

--- a/finq/exceptions.py
+++ b/finq/exceptions.py
@@ -26,6 +26,12 @@ Last updated: 2023-10-21
 """
 
 
+class InvalidCombinationOfArgumentsError(Exception):
+    """ """
+
+    pass
+
+
 class DirectoryNotFoundError(Exception):
     """ """
 

--- a/finq/exceptions.py
+++ b/finq/exceptions.py
@@ -22,8 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-09
-Last updated: 2023-10-18
+Last updated: 2023-10-21
 """
+
+
+class DirectoryNotFoundError(Exception):
+    """ """
+
+    pass
 
 
 class NoFeasibleSolutionError(Exception):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ ignore = [
     "E401",  # unused imports, we do this in submodule __init__.py files
     "E501",  # line too long error, handled by black
     "E722",  # bare `except`
+    "E731",  # do not assign a `lambda` expression, use a `def`
 ]
 
 [tool.black]

--- a/tests/datasets/test_custom.py
+++ b/tests/datasets/test_custom.py
@@ -34,9 +34,8 @@ from pathlib import Path
 
 from .mock_df import _random_df
 from finq.datasets import CustomDataset
+from finq.datautil import default_finq_save_path
 from finq import InvalidCombinationOfArgumentsError
-
-SAVE_PATH = Path.home()
 
 
 class CustomDatasetTest(unittest.TestCase):
@@ -66,13 +65,13 @@ class CustomDatasetTest(unittest.TestCase):
         self._names = names
         self._symbols = symbols
         self._market = "OMX"
-        self._save_path = SAVE_PATH
+        self._save_path = default_finq_save_path()
         self._dataset_name = "CUSTOM_COOL"
 
     def tearDown(self):
         """ """
 
-        path = self._save_path / ".data" / self._dataset_name
+        path = self._save_path / self._dataset_name
 
         if path.is_dir():
             shutil.rmtree(path)
@@ -168,13 +167,13 @@ class CustomDatasetTest(unittest.TestCase):
         self.assertTrue(data_path.is_dir())
 
         self.assertTrue(
-            (self._save_path / ".data" / self._dataset_name / "info").is_dir(),
+            (self._save_path / self._dataset_name / "info").is_dir(),
         )
         self.assertTrue(
-            (self._save_path / ".data" / self._dataset_name / "data").is_dir(),
+            (self._save_path / self._dataset_name / "data").is_dir(),
         )
 
-    @patch("finq.datautil._fetch_names_and_symbols")
+    @patch("finq.datautil.fetch_names_and_symbols")
     @patch("yfinance.Ticker.info", new_callable=PropertyMock)
     @patch("yfinance.Ticker.history")
     def test_fetch_index_data(self, mock_ticker_data, mock_ticker_info, mock_get):
@@ -205,7 +204,7 @@ class CustomDatasetTest(unittest.TestCase):
 
         self.assertEqual(
             dataset._save_path,
-            self._save_path / ".data" / "OMXS30",
+            self._save_path / "OMXS30",
         )
 
         top_stocks = [
@@ -241,14 +240,14 @@ class CustomDatasetTest(unittest.TestCase):
 
         dataset.run("1y")
 
-        info_path = self._save_path / ".data" / self._dataset_name / "info"
-        data_path = self._save_path / ".data" / self._dataset_name / "data"
+        info_path = self._save_path / self._dataset_name / "info"
+        data_path = self._save_path / self._dataset_name / "data"
 
         self.assertTrue(info_path.is_dir())
         self.assertTrue(data_path.is_dir())
         self.assertEqual(
             dataset._save_path,
-            self._save_path / ".data" / self._dataset_name,
+            self._save_path / self._dataset_name,
         )
 
         d = CustomDataset(

--- a/tests/datasets/test_custom.py
+++ b/tests/datasets/test_custom.py
@@ -33,9 +33,10 @@ from unittest.mock import patch, PropertyMock
 from pathlib import Path
 
 from .mock_df import _random_df
-from finq.datasets.custom import CustomDataset
+from finq.datasets import CustomDataset
+from finq import InvalidCombinationOfArgumentsError
 
-SAVE_PATH = ".data/CUSTOM_COOL/"
+SAVE_PATH = Path.home()
 
 
 class CustomDatasetTest(unittest.TestCase):
@@ -43,6 +44,7 @@ class CustomDatasetTest(unittest.TestCase):
 
     def setUp(self):
         """ """
+
         names = [
             "Alfa Laval",
             "Boliden",
@@ -65,13 +67,15 @@ class CustomDatasetTest(unittest.TestCase):
         self._symbols = symbols
         self._market = "OMX"
         self._save_path = SAVE_PATH
+        self._dataset_name = "CUSTOM_COOL"
 
     def tearDown(self):
         """ """
-        path = Path(SAVE_PATH)
+
+        path = self._save_path / ".data" / self._dataset_name
 
         if path.is_dir():
-            shutil.rmtree(SAVE_PATH)
+            shutil.rmtree(path)
 
     @patch("yfinance.Ticker.info", new_callable=PropertyMock)
     @patch("yfinance.Ticker.history")
@@ -89,7 +93,6 @@ class CustomDatasetTest(unittest.TestCase):
             self._names,
             self._symbols,
             market=self._market,
-            save_path=self._save_path,
             save=False,
         )
 
@@ -118,7 +121,6 @@ class CustomDatasetTest(unittest.TestCase):
             self._names,
             self._symbols,
             market=self._market,
-            save_path=self._save_path,
             save=False,
         )
 
@@ -148,6 +150,7 @@ class CustomDatasetTest(unittest.TestCase):
             self._symbols,
             market=self._market,
             save_path=self._save_path,
+            dataset_name=self._dataset_name,
             save=True,
         )
 
@@ -158,8 +161,17 @@ class CustomDatasetTest(unittest.TestCase):
             self._symbols,
         )
 
+        info_path = dataset._save_path / "info"
+        data_path = dataset._save_path / "data"
+
+        self.assertTrue(info_path.is_dir())
+        self.assertTrue(data_path.is_dir())
+
         self.assertTrue(
-            Path(dataset._save_path).is_dir(),
+            (self._save_path / ".data" / self._dataset_name / "info").is_dir(),
+        )
+        self.assertTrue(
+            (self._save_path / ".data" / self._dataset_name / "data").is_dir(),
         )
 
     @patch("finq.datautil._fetch_names_and_symbols")
@@ -193,7 +205,7 @@ class CustomDatasetTest(unittest.TestCase):
 
         self.assertEqual(
             dataset._save_path,
-            Path(".data/OMXS30/"),
+            self._save_path / ".data" / "OMXS30",
         )
 
         top_stocks = [
@@ -223,22 +235,26 @@ class CustomDatasetTest(unittest.TestCase):
             self._symbols,
             market=self._market,
             save_path=self._save_path,
+            dataset_name=self._dataset_name,
             save=True,
         )
 
         dataset.run("1y")
 
-        info_path = Path(self._save_path) / "info"
-        data_path = Path(self._save_path) / "data"
+        info_path = self._save_path / ".data" / self._dataset_name / "info"
+        data_path = self._save_path / ".data" / self._dataset_name / "data"
 
         self.assertTrue(info_path.is_dir())
         self.assertTrue(data_path.is_dir())
+        self.assertEqual(
+            dataset._save_path,
+            self._save_path / ".data" / self._dataset_name,
+        )
 
         d = CustomDataset(
             self._names,
             self._symbols,
             market=self._market,
-            save_path=self._save_path,
             save=False,
         )
 
@@ -251,4 +267,4 @@ class CustomDatasetTest(unittest.TestCase):
 
     def test_all_args_is_none(self):
         """ """
-        self.assertRaises(ValueError, CustomDataset)
+        self.assertRaises(InvalidCombinationOfArgumentsError, CustomDataset)

--- a/tests/datasets/test_ndx.py
+++ b/tests/datasets/test_ndx.py
@@ -28,13 +28,11 @@ Last updated: 2023-10-21
 import shutil
 import unittest
 from unittest.mock import patch, PropertyMock
-from pathlib import Path
 
 from .mock_df import _random_df
 from finq.datasets import NDX
+from finq.datautil import default_finq_save_path
 from finq import Asset
-
-SAVE_PATH = Path.home()
 
 
 class NDXTest(unittest.TestCase):
@@ -43,13 +41,13 @@ class NDXTest(unittest.TestCase):
     def setUp(self):
         """ """
 
-        self._save_path = SAVE_PATH
+        self._save_path = default_finq_save_path()
         self._dataset_name = "NDX"
 
     def tearDown(self):
         """ """
 
-        path = self._save_path / ".data" / self._dataset_name
+        path = self._save_path / self._dataset_name
 
         if path.is_dir():
             shutil.rmtree(path)
@@ -69,8 +67,8 @@ class NDXTest(unittest.TestCase):
         d = NDX(save=True)
         d.run("1y")
 
-        info_path = self._save_path / ".data" / self._dataset_name / "info"
-        data_path = self._save_path / ".data" / self._dataset_name / "data"
+        info_path = self._save_path / self._dataset_name / "info"
+        data_path = self._save_path / self._dataset_name / "data"
 
         self.assertTrue(info_path.is_dir())
         self.assertTrue(data_path.is_dir())

--- a/tests/datasets/test_ndx.py
+++ b/tests/datasets/test_ndx.py
@@ -34,7 +34,7 @@ from .mock_df import _random_df
 from finq.datasets import NDX
 from finq import Asset
 
-SAVE_PATH = ".data/NDX/"
+SAVE_PATH = Path.home()
 
 
 class NDXTest(unittest.TestCase):
@@ -42,14 +42,17 @@ class NDXTest(unittest.TestCase):
 
     def setUp(self):
         """ """
+
         self._save_path = SAVE_PATH
+        self._dataset_name = "NDX"
 
     def tearDown(self):
         """ """
-        path = Path(SAVE_PATH)
+
+        path = self._save_path / ".data" / self._dataset_name
 
         if path.is_dir():
-            shutil.rmtree(SAVE_PATH)
+            shutil.rmtree(path)
 
     @patch("yfinance.Ticker.info", new_callable=PropertyMock)
     @patch("yfinance.Ticker.history")
@@ -66,11 +69,14 @@ class NDXTest(unittest.TestCase):
         d = NDX(save=True)
         d.run("1y")
 
-        info_path = Path(self._save_path) / "info"
-        data_path = Path(self._save_path) / "data"
+        info_path = self._save_path / ".data" / self._dataset_name / "info"
+        data_path = self._save_path / ".data" / self._dataset_name / "data"
 
         self.assertTrue(info_path.is_dir())
         self.assertTrue(data_path.is_dir())
+
+        self.assertTrue((d._save_path / "info").is_dir())
+        self.assertTrue((d._save_path / "data").is_dir())
 
         n = NDX(save=False)
         n.fetch_data("1y")

--- a/tests/datasets/test_omxs30.py
+++ b/tests/datasets/test_omxs30.py
@@ -31,9 +31,8 @@ import numpy as np
 import pandas as pd
 from pathlib import Path
 
+from finq.datautil import default_finq_save_path
 from finq.datasets import OMXS30
-
-SAVE_PATH = Path.home()
 
 
 class OMXS30Test(unittest.TestCase):
@@ -47,13 +46,13 @@ class OMXS30Test(unittest.TestCase):
     def setUp(self):
         """ """
 
-        self._save_path = SAVE_PATH
+        self._save_path = default_finq_save_path()
         self._dataset_name = "OMXS30"
 
     def tearDown(self):
         """ """
 
-        path = self._save_path / ".data" / self._dataset_name
+        path = self._save_path / self._dataset_name
 
         if path.is_dir():
             shutil.rmtree(path)
@@ -83,8 +82,11 @@ class OMXS30Test(unittest.TestCase):
         dataset = OMXS30(save_path=".", save=True)
         dataset.run("6m")
 
+        custom_path = Path(".") / "OMXS30"
         self.assertTrue(dataset._save_path.is_dir())
         self.assertEqual(
             dataset._save_path,
-            Path(".") / ".data" / "OMXS30",
+            custom_path,
         )
+
+        shutil.rmtree(custom_path)

--- a/tests/datasets/test_omxs30.py
+++ b/tests/datasets/test_omxs30.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-12
-Last updated: 2023-10-19
+Last updated: 2023-10-21
 """
 
 import shutil
@@ -33,30 +33,35 @@ from pathlib import Path
 
 from finq.datasets import OMXS30
 
-SAVE_PATH = ".data/OMXS30/"
+SAVE_PATH = Path.home()
 
 
 class OMXS30Test(unittest.TestCase):
-    """NOTE: This is the only index that we will not mock. This is relatively small enough
+    """
+    NOTE: This is the only index that we will not mock. This is relatively small enough
     so we are not generating a lot of traffic when testing without mock. For all other
     tests, we should mock.
+
     """
 
     def setUp(self):
         """ """
+
         self._save_path = SAVE_PATH
+        self._dataset_name = "OMXS30"
 
     def tearDown(self):
         """ """
-        path = Path(SAVE_PATH)
+
+        path = self._save_path / ".data" / self._dataset_name
 
         if path.is_dir():
-            shutil.rmtree(SAVE_PATH)
+            shutil.rmtree(path)
 
     def test_fetch_data_no_save(self):
         """ """
 
-        dataset = OMXS30(save_path=self._save_path, save=False)
+        dataset = OMXS30(save=False)
 
         dataset = dataset.fetch_data("1y").fix_missing_data().verify_data()
         df = dataset["SHB-A.ST"]
@@ -66,7 +71,20 @@ class OMXS30Test(unittest.TestCase):
 
     def test_fetch_data_save(self):
         """ """
+
         dataset = OMXS30(save_path=self._save_path, save=True)
         dataset = dataset.fetch_data("1y").fix_missing_data().verify_data()
 
-        self.assertTrue(Path(dataset._save_path).is_dir())
+        self.assertTrue(dataset._save_path.is_dir())
+
+    def test_fetch_data_save_different_path(self):
+        """ """
+
+        dataset = OMXS30(save_path=".", save=True)
+        dataset.run("6m")
+
+        self.assertTrue(dataset._save_path.is_dir())
+        self.assertEqual(
+            dataset._save_path,
+            Path(".") / ".data" / "OMXS30",
+        )

--- a/tests/datasets/test_omxsbesgni.py
+++ b/tests/datasets/test_omxsbesgni.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-16
-Last updated: 2023-10-19
+Last updated: 2023-10-21
 """
 
 import shutil
@@ -33,7 +33,7 @@ from pathlib import Path
 from .mock_df import _random_df
 from finq.datasets import OMXSBESGNI
 
-SAVE_PATH = ".data/OMXSBESGNI/"
+SAVE_PATH = Path.home()
 
 
 class OMXSBESGNITest(unittest.TestCase):
@@ -41,14 +41,17 @@ class OMXSBESGNITest(unittest.TestCase):
 
     def setUp(self):
         """ """
+
         self._save_path = SAVE_PATH
+        self._dataset_name = "OMXSBESGNI"
 
     def tearDown(self):
         """ """
-        path = Path(SAVE_PATH)
+
+        path = self._save_path / ".data" / self._dataset_name
 
         if path.is_dir():
-            shutil.rmtree(SAVE_PATH)
+            shutil.rmtree(path)
 
     @patch("yfinance.Ticker.info", new_callable=PropertyMock)
     @patch("yfinance.Ticker.history")
@@ -62,16 +65,16 @@ class OMXSBESGNITest(unittest.TestCase):
         df = _random_df(["Open", "High", "Low", "Close"])
         mock_ticker_data.return_value = df
 
-        d = OMXSBESGNI(save=True)
+        d = OMXSBESGNI(save=True, save_path=self._save_path)
         d.run("1y")
 
-        info_path = Path(self._save_path) / "info"
-        data_path = Path(self._save_path) / "data"
+        info_path = self._save_path / ".data" / self._dataset_name / "info"
+        data_path = self._save_path / ".data" / self._dataset_name / "data"
 
         self.assertTrue(info_path.is_dir())
         self.assertTrue(data_path.is_dir())
 
-        n = OMXSBESGNI(save=False)
+        n = OMXSBESGNI(save=False, save_path=self._save_path)
         n.fetch_data("1y")
 
         self.assertEqual(

--- a/tests/datasets/test_omxsbesgni.py
+++ b/tests/datasets/test_omxsbesgni.py
@@ -28,12 +28,10 @@ Last updated: 2023-10-21
 import shutil
 import unittest
 from unittest.mock import patch, PropertyMock
-from pathlib import Path
 
 from .mock_df import _random_df
+from finq.datautil import default_finq_save_path
 from finq.datasets import OMXSBESGNI
-
-SAVE_PATH = Path.home()
 
 
 class OMXSBESGNITest(unittest.TestCase):
@@ -42,13 +40,13 @@ class OMXSBESGNITest(unittest.TestCase):
     def setUp(self):
         """ """
 
-        self._save_path = SAVE_PATH
+        self._save_path = default_finq_save_path()
         self._dataset_name = "OMXSBESGNI"
 
     def tearDown(self):
         """ """
 
-        path = self._save_path / ".data" / self._dataset_name
+        path = self._save_path / self._dataset_name
 
         if path.is_dir():
             shutil.rmtree(path)
@@ -68,8 +66,8 @@ class OMXSBESGNITest(unittest.TestCase):
         d = OMXSBESGNI(save=True, save_path=self._save_path)
         d.run("1y")
 
-        info_path = self._save_path / ".data" / self._dataset_name / "info"
-        data_path = self._save_path / ".data" / self._dataset_name / "data"
+        info_path = self._save_path / self._dataset_name / "info"
+        data_path = self._save_path / self._dataset_name / "data"
 
         self.assertTrue(info_path.is_dir())
         self.assertTrue(data_path.is_dir())

--- a/tests/datautil/test_nasdaq_utils.py
+++ b/tests/datautil/test_nasdaq_utils.py
@@ -22,14 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-13
-Last updated: 2023-10-16
+Last updated: 2023-10-21
 """
 
 import unittest
 import os
 from zipfile import BadZipFile
 
-from finq.datautil import _fetch_names_and_symbols
+from finq.datautil import fetch_names_and_symbols
 
 WRONG_INDEX_NAME = "KEBABXD"
 
@@ -39,10 +39,11 @@ class NasdaqRequestsTest(unittest.TestCase):
 
     def tearDown(self):
         """ """
+
         for file in os.listdir("."):
             if WRONG_INDEX_NAME in file:
                 os.remove(file)
 
     def test_not_supported_index(self):
         """ """
-        self.assertRaises(BadZipFile, _fetch_names_and_symbols, WRONG_INDEX_NAME)
+        self.assertRaises(BadZipFile, fetch_names_and_symbols, WRONG_INDEX_NAME)

--- a/tests/datautil/test_path_utils.py
+++ b/tests/datautil/test_path_utils.py
@@ -1,0 +1,80 @@
+"""
+MIT License
+
+Copyright (c) 2023 Wilhelm Ågren
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+File created: 2023-10-21
+Last updated: 2023-10-21
+"""
+
+import unittest
+import shutil
+
+from pathlib import Path
+from finq.datautil import (
+    default_finq_cache_path,
+    default_finq_save_path,
+    all_tickers_saved,
+)
+
+
+class PathUtilsTests(unittest.TestCase):
+    """ """
+
+    def test_default_finq_cache_path(self):
+        """ """
+
+        path = default_finq_cache_path()
+        self.assertEqual(
+            Path.home() / ".finq" / "http_cache",
+            path,
+        )
+
+    def test_default_finq_save_path(self):
+        """ """
+
+        path = default_finq_save_path()
+        self.assertEqual(
+            Path.home() / ".finq" / "data",
+            path,
+        )
+
+    def test_all_tickers_saved(self):
+        """ """
+
+        test_path = Path.cwd() / ".dummytest"
+
+        test_info_path = test_path / "info"
+        test_data_path = test_path / "data"
+
+        test_info_path.mkdir(parents=True)
+        test_data_path.mkdir(parents=True)
+
+        tickers = ["A", "B", "C", "D", "E"]
+
+        for ticker in tickers:
+            with open(test_info_path / f"{ticker}.json", "w") as f:
+                f.write("dummytest")
+            with open(test_data_path / f"{ticker}.csv", "w") as f:
+                f.write("dummytest")
+
+        self.assertTrue(all_tickers_saved(test_path, tickers))
+        shutil.rmtree(test_path)


### PR DESCRIPTION
# Description

Refactor and add documentation for entire `Dataset` class. Refactor all dataset implementations.
Implement more datautil methods for default paths.
Update all tests.

**NOTE: BREAKING CHANGES FOLLOWING THIS PR**

## Is this change linked to an existing issue?

- [x] https://github.com/wilhelmagren/finq/issues/16


## Any other relevant reference?

N/A
