### PR TITLE
feat(dataset): enable passing proxy to yfinance Ticker on info fetch

### DIFF
--- a/finq/datasets/dataset.py
+++ b/finq/datasets/dataset.py
@@ -363,7 +363,7 @@ class Dataset(object):
             bar.set_description(f"Fetching ticker {ticker} data from Yahoo! Finance")
 
             fetched = yf.Ticker(ticker, session=self._session)
-            info[ticker] = fetched.info
+            info[ticker] = fetched.get_info(proxy=self._proxy)
 
             data[ticker] = fetched.history(
                 period=period,

--- a/tests/datasets/test_custom.py
+++ b/tests/datasets/test_custom.py
@@ -22,14 +22,14 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-11
-Last updated: 2023-10-21
+Last updated: 2023-10-22
 """
 
 import os
 import shutil
 import unittest
 import numpy as np
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch
 from pathlib import Path
 
 from .mock_df import _random_df
@@ -76,7 +76,7 @@ class CustomDatasetTest(unittest.TestCase):
         if path.is_dir():
             shutil.rmtree(path)
 
-    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.get_info")
     @patch("yfinance.Ticker.history")
     def test_fetch_visualize(self, mock_ticker_data, mock_ticker_info):
         """ """
@@ -104,7 +104,7 @@ class CustomDatasetTest(unittest.TestCase):
         self.assertTrue(png_path.exists())
         os.remove(png_path)
 
-    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.get_info")
     @patch("yfinance.Ticker.history")
     def test_fetch_data_no_save(self, mock_ticker_data, mock_ticker_info):
         """ """
@@ -132,7 +132,7 @@ class CustomDatasetTest(unittest.TestCase):
 
         self.assertTrue(isinstance(dataset.as_numpy(), np.ndarray))
 
-    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.get_info")
     @patch("yfinance.Ticker.history")
     def test_fetch_data_save(self, mock_ticker_data, mock_ticker_info):
         """ """
@@ -174,7 +174,7 @@ class CustomDatasetTest(unittest.TestCase):
         )
 
     @patch("finq.datautil.fetch_names_and_symbols")
-    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.get_info")
     @patch("yfinance.Ticker.history")
     def test_fetch_index_data(self, mock_ticker_data, mock_ticker_info, mock_get):
         """ """
@@ -217,7 +217,7 @@ class CustomDatasetTest(unittest.TestCase):
         stocks_found_in_index = all([t in dataset.get_tickers() for t in top_stocks])
         self.assertTrue(stocks_found_in_index)
 
-    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.get_info")
     @patch("yfinance.Ticker.history")
     def test_fetch_then_load(self, mock_ticker_data, mock_ticker_info):
         """ """

--- a/tests/datasets/test_ndx.py
+++ b/tests/datasets/test_ndx.py
@@ -22,12 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-16
-Last updated: 2023-10-21
+Last updated: 2023-10-22
 """
 
 import shutil
 import unittest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch
 
 from .mock_df import _random_df
 from finq.datasets import NDX
@@ -52,7 +52,7 @@ class NDXTest(unittest.TestCase):
         if path.is_dir():
             shutil.rmtree(path)
 
-    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.get_info")
     @patch("yfinance.Ticker.history")
     def test_fetch_then_load(self, mock_ticker_data, mock_ticker_info):
         """ """
@@ -94,7 +94,7 @@ class NDXTest(unittest.TestCase):
             len(n.get_data()["AMD"].index.values),
         )
 
-    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.get_info")
     @patch("yfinance.Ticker.history")
     def test_fetch_then_as_assets(self, mock_ticker_data, mock_ticker_info):
         """ """

--- a/tests/datasets/test_omxs30.py
+++ b/tests/datasets/test_omxs30.py
@@ -22,13 +22,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-12
-Last updated: 2023-10-21
+Last updated: 2023-10-22
 """
 
 import shutil
 import unittest
-import numpy as np
 import pandas as pd
+import numpy as np
 from pathlib import Path
 
 from finq.datautil import default_finq_save_path

--- a/tests/datasets/test_omxsbesgni.py
+++ b/tests/datasets/test_omxsbesgni.py
@@ -22,12 +22,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 File created: 2023-10-16
-Last updated: 2023-10-21
+Last updated: 2023-10-22
 """
 
 import shutil
 import unittest
-from unittest.mock import patch, PropertyMock
+from unittest.mock import patch
 
 from .mock_df import _random_df
 from finq.datautil import default_finq_save_path
@@ -51,7 +51,7 @@ class OMXSBESGNITest(unittest.TestCase):
         if path.is_dir():
             shutil.rmtree(path)
 
-    @patch("yfinance.Ticker.info", new_callable=PropertyMock)
+    @patch("yfinance.Ticker.get_info")
     @patch("yfinance.Ticker.history")
     def test_fetch_then_load(self, mock_ticker_data, mock_ticker_info):
         """ """


### PR DESCRIPTION
# Description

Use `get_info(...)` function instead of using the attribute `info` on the `yf.Ticker(...)` object. This allows us to fetch the ticker information with proxy.

This also allowed us to clean up the mocked tests, because now we don't have to `@patch` an atribute and can instead just mock the function.

## Is this change linked to an existing issue?

- [x] https://github.com/wilhelmagren/finq/issues/50

## Any other relevant reference?

*If changes are inspired by other code, please paste a link to the reference.*

- https://github.com/ranaroussi/yfinance/blob/308e58b914a065f33402bdcb3ed72e2b2d881f64/yfinance/base.py#L1734
